### PR TITLE
Delete create_api.ps1

### DIFF
--- a/create_api.ps1
+++ b/create_api.ps1
@@ -1,1 +1,0 @@
-openapi-generator-cli generate -i .\api-docs\reference\SpaceTraders.json -g rust -o ./api/


### PR DESCRIPTION
- This file used to be used to Generate the Space-Traders API, but since the switch to Spacedust-rs this is no longer necessary