### PR TITLE
Rewrite backend using async for word data download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,28 +1110,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -1139,17 +1123,6 @@ name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -1173,17 +1146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-macro"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.15",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,10 +1163,8 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -3037,7 +2997,6 @@ dependencies = [
  "color-eyre",
  "eframe",
  "egui",
- "futures",
  "image",
  "reqwest",
  "rust-ini",

--- a/trader/Cargo.toml
+++ b/trader/Cargo.toml
@@ -8,7 +8,6 @@ color-eyre = "0.6"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tokio = {version = "1", features = ["full"]}
-futures = "0.3"
 spacedust = "1.0.6"
 eframe = {version = "0.21", features = ["persistence"]}
 egui = "0.21"
@@ -16,4 +15,4 @@ serde = {version = "1", features = ["derive"]}
 rust-ini = "0.19.0"
 serde_json = "1.0"
 image = "0.24.6"
-reqwest = { version = "0.11.18", features = ["blocking"] }
+reqwest = { version = "0.11.18" }

--- a/trader/src/app.rs
+++ b/trader/src/app.rs
@@ -1,12 +1,10 @@
-use std::{
-    collections::VecDeque,
-    sync::{Arc, Mutex},
-};
+use std::{collections::VecDeque, sync::Arc};
+use tokio::sync::Mutex;
 
 use crate::{
     backend::{push_command, Command, CommandData, CommandRequest},
     gamedata::GameData,
-    utils::ExpectLock,
+    utils::ContinueLock,
     windows::{
         agent::AgentData, auth::AuthMenuData, contract_info::ContractInfoData,
         contracts::ContractsData, ship_info::ShipInfoData, ships::ShipMenuData,
@@ -109,7 +107,7 @@ impl eframe::App for TradingGUI {
                 egui::Layout::top_down(egui::Align::LEFT).with_cross_justify(true),
                 |ui| {
                     let menus = Arc::clone(&self.menus);
-                    let mut menus_lock = ExpectLock!(menus.lock());
+                    let mut menus_lock = ContinueLock!(menus.try_lock());
                     for menu in menus_lock.iter_mut() {
                         let menu_name = menu.name().to_owned();
                         ui.toggle_value(menu.visibility(), menu_name);
@@ -126,7 +124,7 @@ impl eframe::App for TradingGUI {
 
         {
             let menus = Arc::clone(&self.menus);
-            let mut menus_lock = ExpectLock!(menus.lock());
+            let mut menus_lock = ContinueLock!(menus.try_lock());
             for i in 0..menus_lock.len() {
                 if *menus_lock[i].visibility() {
                     menus_lock[i].draw(self, ctx);

--- a/trader/src/backend.rs
+++ b/trader/src/backend.rs
@@ -1,4 +1,4 @@
-use crate::parse_system::System;
+use crate::{parse_system::System, utils::ContinueLock};
 use color_eyre::Result;
 use spacedust::{
     apis::{
@@ -14,13 +14,11 @@ use spacedust::{
         Ship,
     },
 };
-use std::{
-    collections::VecDeque,
-    sync::{Arc, Mutex},
-};
+use std::{collections::VecDeque, sync::Arc};
 use tokio::runtime::Runtime;
+use tokio::sync::Mutex;
 
-use crate::utils::{ExpectLock, UnwrapReq};
+use crate::utils::UnwrapReq;
 
 use crate::parse_system::parse_json;
 
@@ -53,7 +51,7 @@ use crate::config::get_config_key;
 use crate::config::set_config_key;
 
 pub fn push_command(msg_queue: &Arc<Mutex<VecDeque<CommandRequest>>>, cmd: CommandRequest) {
-    let mut msg_queue_lock = ExpectLock!(msg_queue.lock());
+    let mut msg_queue_lock = ContinueLock!(msg_queue.try_lock());
     msg_queue_lock.push_front(cmd);
 }
 
@@ -74,70 +72,71 @@ pub fn run_backend(
     let _ = std::thread::spawn(move || {
         let mut config = Configuration::new();
         let rt = Runtime::new().unwrap();
-        loop {
-            std::thread::sleep(std::time::Duration::from_millis(100)); // Allow time for gui to lock
-            let mut msg_queue_lock = ExpectLock!(msg_queue.lock());
-            if msg_queue_lock.is_empty() {
-                drop(msg_queue_lock);
-                continue;
-            }
-            // Check above garanties element
-            let latest_cmd = msg_queue_lock.pop_back().unwrap();
-            dbg!(&latest_cmd.0, &msg_queue_lock);
-            let mut response_data_lock = ExpectLock!(response_data.lock());
-            match latest_cmd.0 {
-                Command::Quit => break,
-                Command::SetToken { token } => {
-                    set_config_key("spacetraders", "token", &token);
-                    config.bearer_access_token = Some(token);
-                }
-                Command::GetMyAgent => {
-                    rt.block_on(async {
+        rt.block_on(async {
+            loop {
+                std::thread::sleep(std::time::Duration::from_millis(100)); // Allow time for gui to lock
+                let latest_cmd = {
+                    let mut msg_queue_lock = msg_queue.lock().await;
+                    if msg_queue_lock.is_empty() {
+                        drop(msg_queue_lock);
+                        continue;
+                    }
+                    // Check above garanties element
+                    msg_queue_lock.pop_back().unwrap()
+                };
+                dbg!(&latest_cmd.0);
+                let mut response_data_lock = response_data.lock().await;
+                match latest_cmd.0 {
+                    Command::Quit => break,
+                    Command::SetToken { token } => {
+                        set_config_key("spacetraders", "token", &token);
+                        config.bearer_access_token = Some(token);
+                    }
+                    Command::GetMyAgent => {
                         response_data_lock.agent_data =
                             UnwrapReq!(get_my_agent(&config).await, latest_cmd.1);
-                    });
-                }
-                Command::GetMyShips => {
-                    rt.block_on(async {
+                    }
+                    Command::GetMyShips => {
                         // TODO: Create Function to get all ships even if list is longer than 20 ships
                         response_data_lock.ships_data = UnwrapReq!(
                             get_my_ships(&config, Some(1), Some(20)).await,
                             latest_cmd.1
                         );
-                    })
-                }
-                Command::Register {
-                    symbol,
-                    faction,
-                    email,
-                } => rt.block_on(async {
-                    let mut request = RegisterRequest::new(faction, symbol);
-                    if !email.is_empty() {
-                        request.email = Some(email);
                     }
-                    response_data_lock.register_data =
-                        UnwrapReq!(register(&config, Some(request)).await, latest_cmd.1);
-                }),
-                Command::GetConfig => {
-                    let token = get_config_key("spacetraders", "token");
-                    config.bearer_access_token = token;
+                    Command::Register {
+                        symbol,
+                        faction,
+                        email,
+                    } => {
+                        let mut request = RegisterRequest::new(faction, symbol);
+                        if !email.is_empty() {
+                            request.email = Some(email);
+                        }
+                        response_data_lock.register_data =
+                            UnwrapReq!(register(&config, Some(request)).await, latest_cmd.1);
+                    }
+                    Command::GetConfig => {
+                        let token = get_config_key("spacetraders", "token");
+                        config.bearer_access_token = token;
+                    }
+                    Command::GetMyContracts => {
+                        response_data_lock.contract_data = UnwrapReq!(
+                            get_contracts(&config, Some(1), Some(20)).await,
+                            latest_cmd.1
+                        );
+                    }
+                    Command::GetUniverse => {
+                        response_data_lock.universe_data =
+                            UnwrapReq!(parse_json().await, latest_cmd.1)
+                    }
+                    Command::Refuel { ship } => {
+                        response_data_lock.refuel_data =
+                            UnwrapReq!(refuel_ship(&config, &ship.symbol, 0).await, latest_cmd.1);
+                    }
                 }
-                Command::GetMyContracts => rt.block_on(async {
-                    response_data_lock.contract_data = UnwrapReq!(
-                        get_contracts(&config, Some(1), Some(20)).await,
-                        latest_cmd.1
-                    );
-                }),
-                Command::GetUniverse => {
-                    response_data_lock.universe_data = UnwrapReq!(parse_json(), latest_cmd.1)
-                }
-                Command::Refuel { ship } => rt.block_on(async {
-                    response_data_lock.refuel_data =
-                        UnwrapReq!(refuel_ship(&config, &ship.symbol, 0).await, latest_cmd.1);
-                }),
+                drop(response_data_lock);
             }
-            drop(response_data_lock);
-        }
+        });
     });
 
     Ok(())

--- a/trader/src/main.rs
+++ b/trader/src/main.rs
@@ -1,8 +1,6 @@
 use color_eyre::Result;
-use std::{
-    collections::VecDeque,
-    sync::{Arc, Mutex},
-};
+use std::{collections::VecDeque, sync::Arc};
+use tokio::sync::Mutex;
 
 mod app;
 mod backend;

--- a/trader/src/utils.rs
+++ b/trader/src/utils.rs
@@ -10,9 +10,15 @@ macro_rules! UnwrapReq {
     };
 }
 
-macro_rules! ExpectLock {
+/// This macro should only ever consume
+/// results from try_locks in the following format:
+/// Result<MutexGuard<'_, T>, TryLockError>
+macro_rules! ContinueLock {
     ($lock_get:expr) => {
-        $lock_get.expect("Tried to aquire lock on Mutex that was owned by panicked thread!")
+        match $lock_get {
+            Ok(v) => v,
+            _ => return,
+        }
     };
 }
 
@@ -22,6 +28,6 @@ macro_rules! Here {
     };
 }
 
-pub(crate) use ExpectLock;
+pub(crate) use ContinueLock;
 pub(crate) use Here;
 pub(crate) use UnwrapReq;

--- a/trader/src/windows/agent.rs
+++ b/trader/src/windows/agent.rs
@@ -1,7 +1,7 @@
 use crate::{
     app::{ControlWindow, TradingGUI},
     backend::{push_command, Command, CommandRequest},
-    utils::ExpectLock,
+    utils::ContinueLock,
 };
 
 #[derive(Debug, Default)]
@@ -43,7 +43,7 @@ impl ControlWindow for AgentData {
                     }
                 });
                 {
-                    let response_data = ExpectLock!(trading_gui.response_data.lock());
+                    let response_data = ContinueLock!(trading_gui.response_data.try_lock());
                     if let Some(v) = &response_data.agent_data {
                         if v.1 == self.name() {
                             trading_gui.game_data.agent_data = Some(*v.0.data.clone());

--- a/trader/src/windows/auth.rs
+++ b/trader/src/windows/auth.rs
@@ -5,7 +5,7 @@ use crate::app::TradingGUI;
 use crate::backend::push_command;
 use crate::backend::Command;
 use crate::backend::CommandRequest;
-use crate::utils::ExpectLock;
+use crate::utils::ContinueLock;
 
 #[derive(Debug, Default)]
 pub struct AuthMenuData {
@@ -86,7 +86,7 @@ impl ControlWindow for AuthMenuData {
         });
 
         {
-            let mut response_data = ExpectLock!(trading_gui.response_data.lock());
+            let mut response_data = ContinueLock!(trading_gui.response_data.try_lock());
             if let Some(v) = &response_data.agent_data {
                 if v.1 == self.name() {
                     trading_gui.game_data.agent_data = Some(*v.0.data.clone());

--- a/trader/src/windows/contracts.rs
+++ b/trader/src/windows/contracts.rs
@@ -1,6 +1,7 @@
 use crate::{
     app::{ControlWindow, TradingGUI},
     backend::{push_command, Command, CommandRequest},
+    utils::ContinueLock,
 };
 #[derive(Debug, Default)]
 pub struct ContractsData {
@@ -37,7 +38,7 @@ impl ControlWindow for ContractsData {
             });
         });
         {
-            let mut response_data = trading_gui.response_data.lock().unwrap();
+            let mut response_data = ContinueLock!(trading_gui.response_data.try_lock());
             if let Some(v) = &response_data.contract_data {
                 if v.1 == self.name() {
                     trading_gui.game_data.contract_data = Some(v.0.data.to_owned());

--- a/trader/src/windows/ship_info.rs
+++ b/trader/src/windows/ship_info.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use crate::{
     app::{ControlWindow, TradingGUI},
     backend::{push_command, Command, CommandRequest},
-    utils::ExpectLock,
+    utils::ContinueLock,
 };
 
 #[derive(Debug, Default)]
@@ -281,7 +281,7 @@ impl ControlWindow for ShipInfoData {
                                 CommandRequest(Command::GetMyShips, self.name()),
                             );
                         }
-                        let mut response_data = ExpectLock!(trading_gui.response_data.lock());
+                        let mut response_data = ContinueLock!(trading_gui.response_data.try_lock());
                         if let Some(v) = &response_data.ships_data {
                             if v.1 == self.name() {
                                 trading_gui.game_data.ship_data = Some(v.0.data.to_owned());

--- a/trader/src/windows/ships.rs
+++ b/trader/src/windows/ships.rs
@@ -1,7 +1,7 @@
 use crate::{
     app::{ControlWindow, TradingGUI},
     backend::{push_command, Command, CommandRequest},
-    utils::ExpectLock,
+    utils::ContinueLock,
 };
 
 #[derive(Debug, Default)]
@@ -39,7 +39,7 @@ impl ControlWindow for ShipMenuData {
         });
 
         {
-            let mut response_data = ExpectLock!(trading_gui.response_data.lock());
+            let mut response_data = ContinueLock!(trading_gui.response_data.try_lock());
             if let Some(v) = &response_data.ships_data {
                 if v.1 == self.name() {
                     trading_gui.game_data.ship_data = Some(v.0.data.to_owned());

--- a/trader/src/windows/world_explorer.rs
+++ b/trader/src/windows/world_explorer.rs
@@ -2,11 +2,12 @@ use crate::app::{ControlWindow, TradingGUI};
 use crate::backend::push_command;
 use crate::backend::Command;
 use crate::backend::CommandRequest;
-use crate::utils::ExpectLock;
+use crate::utils::ContinueLock;
 use egui::epaint::ahash::{HashMap, HashMapExt};
 use egui::plot::{Line, MarkerShape, PlotPoints, Points};
 use egui::*;
 use plot::{Corner, Legend, Plot, PlotPoint, Text};
+
 #[derive(Debug, Default)]
 pub struct WorldExplorerData {
     only_show_systems_with_ships: bool,
@@ -162,7 +163,7 @@ impl ControlWindow for WorldExplorerData {
         });
 
         {
-            let mut response_data = ExpectLock!(trading_gui.response_data.lock());
+            let mut response_data = ContinueLock!(trading_gui.response_data.try_lock());
             if let Some(v) = &response_data.universe_data {
                 if v.1 == self.name() {
                     trading_gui.game_data.universe_data = Some(v.clone().0);


### PR DESCRIPTION
- parse_json now async
- download_file now async
- fixed crash in download_file where tokio runtime is killed (https://github.com/seanmonstar/reqwest/issues/1017)
- make backend use one large async block instead of many small ones, allowing for actual async instead of just blocking

- Fix issue where GUI would block waiting for backend
- (Related to above) now using tokio::sync::mutex instead of std::sync::mutex
- New ContinueLock Macro